### PR TITLE
versioned library format + header files

### DIFF
--- a/tools/legacy/metrics_monitor/CMakeLists.txt
+++ b/tools/legacy/metrics_monitor/CMakeLists.txt
@@ -97,8 +97,14 @@ if(PKG_LIBDRM_FOUND)
   target_compile_definitions(${METRICS_TOOL} PRIVATE LIBVA_DRM_SUPPORT
                                                      LIBVA_SUPPORT)
 
+  set_target_properties(${METRICS_LIB} PROPERTIES VERSION 1.0.0)
+
   install(TARGETS ${METRICS_TOOL} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                                           COMPONENT ${VPL_COMPONENT_TOOLS})
+
+  install(
+    FILES "include/cttmetrics.h" "include/cttmetrics_utils.h"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cttmetrics")
 
   # test_monitor
   if(BUILD_TESTS)

--- a/tools/legacy/sample_misc/wayland/CMakeLists.txt
+++ b/tools/legacy/sample_misc/wayland/CMakeLists.txt
@@ -112,8 +112,10 @@ if(PKGConfig_LIBDRM_FOUND)
   target_link_libraries(${TARGET} PRIVATE sample_common wayland-client va drm
                                           drm_intel)
 
+  set_target_properties(${TARGET} PROPERTIES VERSION 1.0.0)
+
   install(TARGETS ${TARGET}
-          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}"
+          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
                   COMPONENT ${VPL_COMPONENT_TOOLS})
 else()
   message(


### PR DESCRIPTION
## Issue
We're packing this tool for Fedora and there are some packaging requirements

> When a shared library file is only provided in an unversioned format, the packager should ask upstream to consider providing a properly versioned library file.

https://docs.fedoraproject.org/en-US/packaging-guidelines/#_devel_packages

