### PR TITLE
Add support for Intel Media Transcode Accelerator

### DIFF
--- a/tools/legacy/sample_common/src/vaapi_utils_drm.cpp
+++ b/tools/legacy/sample_common/src/vaapi_utils_drm.cpp
@@ -21,9 +21,10 @@
 constexpr mfxU32 MFX_DRI_MAX_NODES_NUM      = 16;
 constexpr mfxU32 MFX_DRI_RENDER_START_INDEX = 128;
 constexpr mfxU32 MFX_DRI_CARD_START_INDEX   = 0;
-constexpr mfxU32 MFX_DRM_DRIVER_NAME_LEN    = 4;
+constexpr mfxU32 MFX_DRM_DRIVER_NAME_LEN    = 32;
 const char* MFX_DRM_INTEL_DRIVER_NAME       = "i915";
 const char* MFX_DRM_INTEL_DRIVER_XE_NAME    = "xe";
+const char* MFX_DRM_INTEL_DRIVER_MTA_NAME   = "media_transcode_accelerator";
 const char* MFX_DRI_PATH                    = "/dev/dri/";
 const char* MFX_DRI_NODE_RENDER             = "renderD";
 const char* MFX_DRI_NODE_CARD               = "card";
@@ -63,7 +64,8 @@ int open_first_intel_adapter(int type) {
 
         if (!get_drm_driver_name(fd, driverName, MFX_DRM_DRIVER_NAME_LEN) &&
             (msdk_match(driverName, MFX_DRM_INTEL_DRIVER_NAME) ||
-             msdk_match(driverName, MFX_DRM_INTEL_DRIVER_XE_NAME))) {
+             msdk_match(driverName, MFX_DRM_INTEL_DRIVER_XE_NAME) ||
+             msdk_match(driverName, MFX_DRM_INTEL_DRIVER_MTA_NAME))) {
             return fd;
         }
         close(fd);
@@ -116,7 +118,8 @@ int open_intel_adapter(const std::string& devicePath, int type) {
     char driverName[MFX_DRM_DRIVER_NAME_LEN + 1] = {};
     if (!get_drm_driver_name(fd, driverName, MFX_DRM_DRIVER_NAME_LEN) &&
         (msdk_match(driverName, MFX_DRM_INTEL_DRIVER_NAME) ||
-         msdk_match(driverName, MFX_DRM_INTEL_DRIVER_XE_NAME))) {
+         msdk_match(driverName, MFX_DRM_INTEL_DRIVER_XE_NAME) ||
+         msdk_match(driverName, MFX_DRM_INTEL_DRIVER_MTA_NAME))) {
         return fd;
     }
     else {
@@ -167,8 +170,7 @@ struct drmMonitorsTable {
 };
 
 drmMonitorsTable g_drmMonitorsTable[] = {
-    #define __DECLARE(type) \
-        { MFX_MONITOR_##type, DRM_MODE_CONNECTOR_##type, #type }
+    #define __DECLARE(type) { MFX_MONITOR_##type, DRM_MODE_CONNECTOR_##type, #type }
     __DECLARE(Unknown),   __DECLARE(VGA),       __DECLARE(DVII),        __DECLARE(DVID),
     __DECLARE(DVIA),      __DECLARE(Composite), __DECLARE(SVIDEO),      __DECLARE(LVDS),
     __DECLARE(Component), __DECLARE(9PinDIN),   __DECLARE(HDMIA),       __DECLARE(HDMIB),


### PR DESCRIPTION
Intel Media Transcode Accelerator added as supported device

## Issue
Intel Media Transcode Accelerator is not recognized as Intel device
JIRA issue: https://jira.devtools.intel.com/browse/VCX-1957

## Solution
Intel Media Transcode Accelerator is added as recognized Intel device as well as i915 and xe.
MFX_DRM_DRIVER_NAME_LEN is extended to 32 characters to support "media_transcode_accelerator" name.

## How Tested
Tested with media_ip dev package: https://af01p-igk.devtools.intel.com/artifactory/gnrd-media-ip-igk-local/builds/develop/GNR-D_MediaIP_Dev_296/artifacts/GNR-D_MediaIP_Dev_296.tgz
[sample_multi_transcode_cmds.txt](https://github.com/user-attachments/files/19243533/sample_multi_transcode_cmds.txt)

