### PR TITLE
Add cstdint header to resolve build issue with gcc-15

### DIFF
--- a/tools/legacy/sample_vpp/src/sample_vpp_frc_adv.cpp
+++ b/tools/legacy/sample_vpp/src/sample_vpp_frc_adv.cpp
@@ -5,6 +5,7 @@
   ############################################################################*/
 
 #include "sample_vpp_frc_adv.h"
+#include <cstdint>
 #include <math.h>
 #include <algorithm>
 #include "vm/strings_defs.h"


### PR DESCRIPTION
Following build issue is observed when building libvpl-tools in yocto project with gcc-15

| /poky_master/build/tmp/work/corei7-64-poky-linux/libvpl-tools/1.4.0/git/tools/legacy/sample_vpp/src/sample_vpp_frc_adv.cpp: In member function 'virtual mfxStatus FRCAdvancedChecker::Init(mfxVideoParam*, mfxU32)':
| /poky_master/build/tmp/work/corei7-64-poky-linux/libvpl-tools/1.4.0/git/tools/legacy/sample_vpp/src/sample_vpp_frc_adv.cpp:60:11: error: 'uint64_t' was not declared in this scope
| 60 | ((uint64_t)m_videoParam.vpp.In.FrameRateExtD * (uint64_t)MFX_TIME_STAMP_FREQUENCY) /
| | ^~~~~~~~
| /poky_master/build/tmp/work/corei7-64-poky-linux/libvpl-tools/1.4.0/git/tools/legacy/sample_vpp/src/sample_vpp_frc_adv.cpp:11:1: note: 'uint64_t' is defined in header ''; this is probably fixable by adding '#include '
| 10 | #include "vm/strings_defs.h"
| +++ |+#include
| 11 |
| /poky_master/build/tmp/work/corei7-64-poky-linux/libvpl-tools/1.4.0/git/tools/legacy/sample_vpp/src/sample_vpp_frc_adv.cpp:60:20: error: expected ')' before 'm_videoParam'
| 60 | ((uint64_t)m_videoParam.vpp.In.FrameRateExtD * (uint64_t)MFX_TIME_STAMP_FREQUENCY) /
| | ~ ^~~~~~~~~~~~
| | )